### PR TITLE
Update ConnectionsModule.psm1

### DIFF
--- a/Modules/ConnectionsModule.psm1
+++ b/Modules/ConnectionsModule.psm1
@@ -413,7 +413,7 @@ function Test-FiberSatellite
 {0}
 {2}
 {3}
-'@ -f $(f_$OutputTable.Report), ('-' * 31), ('You can find the full report at: {0}' -f $ReportFile), ('=' * 31))
+'@ -f $($OutputTable.Report), ('-' * 31), ('You can find the full report at: {0}' -f $ReportFile), ('=' * 31))
 
   $LogOutput | Add-Content -Path $ReportFile
     


### PR DESCRIPTION
Issue: 'f_$OutputTable.Report' is not recognized

#### Issue:
During an edit at one point, a "f_" was added to the variable name. 
C:\Users\erika\Documents\WindowsPowerShell\Modules\ITPS.OMCS.Tools\1.11.1.7\Modules\ConnectionsModule.psm1
Line: 416
Char: 9

#### Repair:
Remove the "f_"

Corrected: 
The errant syntax has been removed and the function tested 