### PR TITLE
Run as admin error - fix

### DIFF
--- a/Scripts/Repair-WindowsUpdate.ps1
+++ b/Scripts/Repair-WindowsUpdate.ps1
@@ -3,7 +3,7 @@
   #requires -Version 3.0
   <#PSScriptInfo
     
-      .VERSION 1.0
+      .VERSION 2.0
     
       .GUID ebdf766e-f61c-49a4-a764-1102ed0ac4dc
     


### PR DESCRIPTION
Addresses and resolves #29 

Adds test for admin before running the actual commands.
This test can be found in _ITPS.OMCS.Snippets_ "ks: test for admin"